### PR TITLE
Replace log4j with logback and ship to ELK

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,13 +14,14 @@ val playVersion = "2.5.0"
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
   "com.amazonaws" % "aws-lambda-java-events" % "1.1.0",
-  "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0",
-  "org.slf4j" % "slf4j-log4j12" % "1.7.21",
   "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-lambda" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-kinesis" % awsVersion,
   "com.typesafe.play" %% "play-json" % playVersion,
   "com.typesafe.play" %% "play-ws" % playVersion,
+  "ch.qos.logback" % "logback-classic" % "1.1.7",
+  "net.logstash.logback" % "logstash-logback-encoder" % "4.6",
+  "com.gu" % "kinesis-logback-appender" % "1.2.0",
   "org.scalatest" %% "scalatest" % "2.2.5" % "test"
 )
 

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,9 +1,0 @@
-log=.
-log4j.rootLogger=INFO,LAMBDA
-
-log4j.logger.io.netty=WARN,LAMBDA
-
-#Define the LAMBDA appender
-log4j.appender.LAMBDA=com.amazonaws.services.lambda.runtime.log4j.LambdaAppender
-log4j.appender.LAMBDA.layout=org.apache.log4j.PatternLayout
-log4j.appender.LAMBDA.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} <%X{AWSRequestId}> %-5p %c{1}:%L - %m%n

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+    <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+        <target>System.err</target>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDERR" />
+    </root>
+</configuration>

--- a/src/main/scala/com/gu/flexible/snapshotter/config/LogStash.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/config/LogStash.scala
@@ -1,0 +1,71 @@
+package com.gu.flexible.snapshotter.config
+
+import ch.qos.logback.classic.{Logger, LoggerContext}
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.joran.spi.JoranException
+import ch.qos.logback.core.util.StatusPrinter
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.regions.{Region, Regions}
+import com.gu.flexible.snapshotter.Logging
+import com.gu.logback.appender.kinesis.KinesisAppender
+import net.logstash.logback.layout.LogstashLayout
+import org.slf4j.LoggerFactory
+
+case class KinesisAppenderConfig(
+  stream: String,
+  credentialsProvider: AWSCredentialsProvider,
+  region: Regions,
+  bufferSize: Int = 1000
+)
+
+object LogStash extends Logging {
+  var initialised = false
+
+  def enableLogstashKinesisHandler(config: KinesisAppenderConfig, customFields: (String, String)*) =
+    init(config, customFields.toMap)
+
+  def makeCustomFields(customFields: Map[String,String]): String = {
+    "{" + (for((k, v) <- customFields) yield(s""""${k}":"${v}"""")).mkString(",") + "}"
+  }
+
+  def makeLayout(customFields: String) = {
+    val l = new LogstashLayout()
+    l.setCustomFields(customFields)
+    l
+  }
+
+  def makeKinesisAppender(layout: LogstashLayout, context: LoggerContext, appenderConfig: KinesisAppenderConfig) = {
+    val a = new KinesisAppender[ILoggingEvent]()
+    a.setStreamName(appenderConfig.stream)
+    a.setRegion(appenderConfig.region.getName)
+    a.setCredentialsProvider(appenderConfig.credentialsProvider)
+    a.setBufferSize(appenderConfig.bufferSize)
+
+    a.setContext(context)
+    a.setLayout(layout)
+
+    layout.start()
+    a.start()
+    a
+  }
+
+  def init(config: KinesisAppenderConfig, customFields: Map[String, String]) {
+    if (!initialised) {
+      val context = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
+      try {
+        val layout = makeLayout(makeCustomFields(customFields))
+        val appender = makeKinesisAppender(layout, context, config)
+        val rootLogger = LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME).asInstanceOf[Logger]
+        rootLogger.addAppender(appender)
+        initialised = true
+      } catch {
+        case e: JoranException => // ignore, errors will be printed below
+      }
+
+      StatusPrinter.printInCaseOfErrorsOrWarnings(context)
+      log.info("Logstash appender now initialised")
+    } else {
+      log.info("Logstash already initialised")
+    }
+  }
+}

--- a/src/main/scala/com/gu/flexible/snapshotter/config/SchedulerConfig.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/config/SchedulerConfig.scala
@@ -8,17 +8,18 @@ import play.api.libs.json.{Json, Reads}
 object LambdaSchedulerConfig {
   implicit val configReads = Json.reads[LambdaSchedulerConfig]
 }
-case class LambdaSchedulerConfig(kinesisStream: String)
+case class LambdaSchedulerConfig(kinesisStream: String, logstashStream: Option[String])
 
 case class SchedulerConfig(
   kinesisStream: String,
   apiUrl: String,
+  logstashKinesisStream: Option[String] = None,
   region: Region = Regions.getCurrentRegion) extends CommonConfig
 
 object SchedulerConfig {
   def resolve(stage: String, context: Context)(implicit lambdaClient: AWSLambdaClient): SchedulerConfig = {
     val lambdaJson = LambdaConfig.getDescriptionJson(context)
     val lambdaConfig = lambdaJson.as[LambdaSchedulerConfig]
-    SchedulerConfig(lambdaConfig.kinesisStream, Config.apiUrl(stage))
+    SchedulerConfig(lambdaConfig.kinesisStream, Config.apiUrl(stage), lambdaConfig.logstashStream)
   }
 }

--- a/src/main/scala/com/gu/flexible/snapshotter/config/SnapshotterConfig.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/config/SnapshotterConfig.scala
@@ -8,19 +8,20 @@ import play.api.libs.json.Json
 object LambdaSnapshotterConfig {
   implicit val configReads = Json.reads[LambdaSnapshotterConfig]
 }
-case class LambdaSnapshotterConfig(bucket: String, kmsKey: Option[String])
+case class LambdaSnapshotterConfig(bucket: String, kmsKey: Option[String], logstashSteam:Option[String])
 
 case class SnapshotterConfig(
   bucket: String,
   apiUrl: String,
   kmsKey: Option[String] = None,
+  logstashStream: Option[String] = None,
   region: Region = Regions.getCurrentRegion) extends CommonConfig
 
 object SnapshotterConfig {
   def resolve(stage: String, context: Context)(implicit lambdaClient: AWSLambdaClient): SnapshotterConfig = {
     val lambdaJson = LambdaConfig.getDescriptionJson(context)
     val lambdaConfig = lambdaJson.as[LambdaSnapshotterConfig]
-    SnapshotterConfig(lambdaConfig.bucket, Config.apiUrl(stage), lambdaConfig.kmsKey)
+    SnapshotterConfig(lambdaConfig.bucket, Config.apiUrl(stage), lambdaConfig.logstashSteam, lambdaConfig.kmsKey)
   }
 }
 

--- a/src/main/scala/com/gu/flexible/snapshotter/logic/ApiLogic.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/logic/ApiLogic.scala
@@ -3,6 +3,7 @@ package com.gu.flexible.snapshotter.logic
 import com.gu.flexible.snapshotter.model._
 import com.gu.flexible.snapshotter.Logging
 import com.gu.flexible.snapshotter.config.CommonConfig
+import net.logstash.logback.marker.Markers
 import org.joda.time.DateTime
 import play.api.http.Status
 import play.api.libs.json.{JsObject, JsValue}
@@ -19,7 +20,7 @@ object ApiLogic extends Logging {
 
   def contentForId(id: String)(implicit ws:WSClient, config:CommonConfig, context:ExecutionContext): Attempt[JsValue] = {
     val request = ws.url(s"${config.contentRawUri}/$id").withQueryString("includePreview"->"true", "includeLive"->"true")
-    log.info(s"Requesting content for ID $id")
+    log.info(Markers.append("contentId", id), s"Requesting content for ID $id")
     jsonOnOKStatus(request)
   }
 

--- a/src/main/scala/com/gu/flexible/snapshotter/mainclasses/SchedulingLambdaRunner.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/mainclasses/SchedulingLambdaRunner.scala
@@ -10,7 +10,11 @@ object SchedulingLambdaRunner extends App {
 
   val sl = new SchedulingLambda()
   val result = sl.schedule(
-    new SchedulerConfig(kinesisStream, Config.apiUrl("DEV"), Region.getRegion(Regions.EU_WEST_1)),
+    new SchedulerConfig(
+      kinesisStream,
+      Config.apiUrl("DEV"),
+      region = Region.getRegion(Regions.EU_WEST_1)
+    ),
     new FakeContext()
   )
   val fin = SchedulingLambda.logResult(result)


### PR DESCRIPTION
This starts to ship logs to ELK and so I decided to switch to Logback and ditch the AWS log4j integration.
