### PR TITLE
Cloudwatch metrics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ scalaVersion in ThisBuild := "2.11.8"
 description   := "AWS lambdas to snapshot Flexible content to S3"
 scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked")
 
-val awsVersion = "1.11.0"
+val awsVersion = "1.11.5"
 val playVersion = "2.5.0"
 
 libraryDependencies ++= Seq(
@@ -19,6 +19,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-lambda" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-kinesis" % awsVersion,
+  "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion,
   "com.typesafe.play" %% "play-json" % playVersion,
   "com.typesafe.play" %% "play-ws" % playVersion,
   "org.scalatest" %% "scalatest" % "2.2.5" % "test"

--- a/src/main/scala/com/gu/flexible/snapshotter/SchedulingLambda.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/SchedulingLambda.scala
@@ -69,12 +69,12 @@ object SchedulingLambda extends Logging {
       { errors =>
         errors.errors.foreach(_.logTo(log))
         CloudWatchLogic.putMetricData(
-          "scheduledContentIdsError" -> MetricValue(errors.errors.size, MetricValue.Count)
+          MetricName.scheduledContentIdsError -> MetricValue(errors.errors.size, MetricValue.Count)
         )
       }, { kinesisResults =>
         log.info(s"SUCCESS: $kinesisResults")
         CloudWatchLogic.putMetricData(
-          "scheduledContentIdsSuccess" -> MetricValue(kinesisResults.size, MetricValue.Count)
+          MetricName.scheduledContentIdsSuccess -> MetricValue(kinesisResults.size, MetricValue.Count)
         )
       }
     )

--- a/src/main/scala/com/gu/flexible/snapshotter/SnapshottingLambda.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/SnapshottingLambda.scala
@@ -66,7 +66,8 @@ object SnapshottingLambda extends Logging {
     results.fold(
       { failed =>
         CloudWatchLogic.putMetricData(
-          "contentSnapshotError" -> MetricValue(failed.errors.size, MetricValue.Count)
+          // this key is referenced in the cloudformation - don't change it!
+          MetricName.contentSnapshotError -> MetricValue(failed.errors.size, MetricValue.Count)
         )
         Future.successful(failed.errors.foreach(_.logTo(log)))
       },
@@ -75,12 +76,13 @@ object SnapshottingLambda extends Logging {
           attempts.foreach {
             case Left(failures) =>
               CloudWatchLogic.putMetricData(
-                "contentSnapshotError" -> MetricValue(failures.errors.size, MetricValue.Count)
+                // this key is referenced in the cloudformation - don't change it!
+                MetricName.contentSnapshotError -> MetricValue(failures.errors.size, MetricValue.Count)
               )
               failures.errors.foreach(_.logTo(log))
             case Right(result) =>
               CloudWatchLogic.putMetricData(
-                "contentSnapshotSuccess" -> MetricValue(1.0, MetricValue.Count)
+                MetricName.contentSnapshotSuccess -> MetricValue(1.0, MetricValue.Count)
               )
               log.info(s"SUCCESS: $result")
           }

--- a/src/main/scala/com/gu/flexible/snapshotter/config/Config.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/config/Config.scala
@@ -29,8 +29,13 @@ object LambdaConfig {
 }
 
 trait CommonConfig {
-  def apiUrl: String
   def region: Region
+  def cloudWatchNameSpace: String = "SnapshotterLambdas"
+  def cloudWatchDimensions: Seq[(String,String)] = Seq("Stage" -> stage, "Lambda" -> app)
+  def stage: String
+  def app: String
+
+  def apiUrl: String = Config.apiUrl(stage)
 
   def contentUri = s"$apiUrl/content"
   def contentRawUri = s"$apiUrl/contentRaw"

--- a/src/main/scala/com/gu/flexible/snapshotter/config/Config.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/config/Config.scala
@@ -31,9 +31,8 @@ object LambdaConfig {
 trait CommonConfig {
   def region: Region
   def cloudWatchNameSpace: String = "SnapshotterLambdas"
-  def cloudWatchDimensions: Seq[(String,String)] = Seq("Stage" -> stage, "Lambda" -> app)
+  def cloudWatchDimensions: Seq[(String,String)] = Seq("Stage" -> stage)
   def stage: String
-  def app: String
 
   def apiUrl: String = Config.apiUrl(stage)
 

--- a/src/main/scala/com/gu/flexible/snapshotter/config/SchedulerConfig.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/config/SchedulerConfig.scala
@@ -13,9 +13,7 @@ case class LambdaSchedulerConfig(kinesisStream: String)
 case class SchedulerConfig(
   kinesisStream: String,
   stage: String,
-  region: Region = Regions.getCurrentRegion) extends CommonConfig {
-  val app = "scheduler"
-}
+  region: Region = Regions.getCurrentRegion) extends CommonConfig
 
 object SchedulerConfig {
   def resolve(stage: String, context: Context)(implicit lambdaClient: AWSLambdaClient): SchedulerConfig = {

--- a/src/main/scala/com/gu/flexible/snapshotter/config/SchedulerConfig.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/config/SchedulerConfig.scala
@@ -12,13 +12,18 @@ case class LambdaSchedulerConfig(kinesisStream: String)
 
 case class SchedulerConfig(
   kinesisStream: String,
-  apiUrl: String,
-  region: Region = Regions.getCurrentRegion) extends CommonConfig
+  stage: String,
+  region: Region = Regions.getCurrentRegion) extends CommonConfig {
+  val app = "scheduler"
+}
 
 object SchedulerConfig {
   def resolve(stage: String, context: Context)(implicit lambdaClient: AWSLambdaClient): SchedulerConfig = {
     val lambdaJson = LambdaConfig.getDescriptionJson(context)
     val lambdaConfig = lambdaJson.as[LambdaSchedulerConfig]
-    SchedulerConfig(lambdaConfig.kinesisStream, Config.apiUrl(stage))
+    SchedulerConfig(
+      kinesisStream = lambdaConfig.kinesisStream,
+      stage = stage
+    )
   }
 }

--- a/src/main/scala/com/gu/flexible/snapshotter/config/SnapshotterConfig.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/config/SnapshotterConfig.scala
@@ -14,9 +14,7 @@ case class SnapshotterConfig(
   bucket: String,
   stage: String,
   kmsKey: Option[String] = None,
-  region: Region = Regions.getCurrentRegion) extends CommonConfig {
-  val app = "snapshotter"
-}
+  region: Region = Regions.getCurrentRegion) extends CommonConfig
 
 object SnapshotterConfig {
   def resolve(stage: String, context: Context)(implicit lambdaClient: AWSLambdaClient): SnapshotterConfig = {

--- a/src/main/scala/com/gu/flexible/snapshotter/config/SnapshotterConfig.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/config/SnapshotterConfig.scala
@@ -12,15 +12,21 @@ case class LambdaSnapshotterConfig(bucket: String, kmsKey: Option[String])
 
 case class SnapshotterConfig(
   bucket: String,
-  apiUrl: String,
+  stage: String,
   kmsKey: Option[String] = None,
-  region: Region = Regions.getCurrentRegion) extends CommonConfig
+  region: Region = Regions.getCurrentRegion) extends CommonConfig {
+  val app = "snapshotter"
+}
 
 object SnapshotterConfig {
   def resolve(stage: String, context: Context)(implicit lambdaClient: AWSLambdaClient): SnapshotterConfig = {
     val lambdaJson = LambdaConfig.getDescriptionJson(context)
     val lambdaConfig = lambdaJson.as[LambdaSnapshotterConfig]
-    SnapshotterConfig(lambdaConfig.bucket, Config.apiUrl(stage), lambdaConfig.kmsKey)
+    SnapshotterConfig(
+      bucket = lambdaConfig.bucket,
+      stage = stage,
+      kmsKey = lambdaConfig.kmsKey
+    )
   }
 }
 

--- a/src/main/scala/com/gu/flexible/snapshotter/logic/CloudWatchLogic.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/logic/CloudWatchLogic.scala
@@ -1,0 +1,32 @@
+package com.gu.flexible.snapshotter.logic
+
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient
+import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest, StandardUnit}
+import com.gu.flexible.snapshotter.Logging
+import com.gu.flexible.snapshotter.config.CommonConfig
+
+import scala.util.control.NonFatal
+
+object MetricValue {
+  val None = StandardUnit.None.toString
+  val Count = StandardUnit.Count.toString
+}
+case class MetricValue(value: Double, unit: String = MetricValue.None)
+
+object CloudWatchLogic extends Logging {
+  def awsDimensions(dimensions: (String, String)*) = {
+    dimensions.map{ case (name, value) => new Dimension().withName(name).withValue(value) }
+  }
+
+  def putMetricData(metrics: (String, MetricValue)*)(implicit cloudWatchClient: AmazonCloudWatchClient, config: CommonConfig) = {
+    val dimensions = awsDimensions(config.cloudWatchDimensions:_*)
+    val metricData = metrics.map { case (name, value) =>
+      new MetricDatum().withMetricName(name).withUnit(value.unit).withValue(value.value).withDimensions(dimensions:_*)
+    }
+    try {
+      cloudWatchClient.putMetricData(new PutMetricDataRequest().withNamespace(config.cloudWatchNameSpace).withMetricData(metricData:_*))
+    } catch {
+      case NonFatal(e) => log.warn(s"Could't post metrics $metrics", e)
+    }
+  }
+}

--- a/src/main/scala/com/gu/flexible/snapshotter/logic/CloudWatchLogic.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/logic/CloudWatchLogic.scala
@@ -13,6 +13,14 @@ object MetricValue {
 }
 case class MetricValue(value: Double, unit: String = MetricValue.None)
 
+object MetricName {
+  // these keys are referenced in the cloudformation - don't change them!
+  val contentSnapshotError = "contentSnapshotError"
+  val contentSnapshotSuccess = "contentSnapshotSuccess"
+  val scheduledContentIdsError = "scheduledContentIdsError"
+  val scheduledContentIdsSuccess = "scheduledContentIdsSuccess"
+}
+
 object CloudWatchLogic extends Logging {
   def awsDimensions(dimensions: (String, String)*) = {
     dimensions.map{ case (name, value) => new Dimension().withName(name).withValue(value) }

--- a/src/main/scala/com/gu/flexible/snapshotter/mainclasses/SchedulingLambdaRunner.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/mainclasses/SchedulingLambdaRunner.scala
@@ -9,11 +9,15 @@ object SchedulingLambdaRunner extends App {
   val kinesisStream:String = ???
 
   val sl = new SchedulingLambda()
-  val result = sl.schedule(
-    new SchedulerConfig(kinesisStream, Config.apiUrl("DEV"), Region.getRegion(Regions.EU_WEST_1)),
-    new FakeContext()
+
+  implicit val config = new SchedulerConfig(
+    kinesisStream = kinesisStream,
+    stage = "DEV",
+    region = Region.getRegion(Regions.EU_WEST_1)
   )
-  val fin = SchedulingLambda.logResult(result)
+
+  val result = sl.schedule(config, new FakeContext())
+  val fin = SchedulingLambda.logResult(result)(sl.cloudWatchClient, config)
   FutureUtils.await(fin)
   sl.shutdown()
 }

--- a/src/main/scala/com/gu/flexible/snapshotter/mainclasses/SnapshottingLambdaRunner.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/mainclasses/SnapshottingLambdaRunner.scala
@@ -13,11 +13,16 @@ object SnapshottingLambdaRunner extends App {
 
   val sl = new SnapshottingLambda()
   val input:Seq[ByteBuffer] = Seq(KinesisLogic.serialiseToByteBuffer(SnapshotRequest("572dda3af7d0f2a7e4bbfb73", SnapshotMetadata("Testing"))))
+  val config = new SnapshotterConfig(
+    bucket = bucket,
+    stage = "DEV",
+    region = Region.getRegion(Regions.EU_WEST_1)
+  )
   val results = sl.snapshot(input,
-    new SnapshotterConfig(bucket, Config.apiUrl("DEV"), region = Region.getRegion(Regions.EU_WEST_1)),
+    config,
     new FakeContext()
   )
-  val fin = SnapshottingLambda.logResults(results)
+  val fin = SnapshottingLambda.logResults(results)(sl.cloudWatchClient, config)
   FutureUtils.await(fin)
   sl.shutdown()
 }

--- a/src/main/scala/com/gu/flexible/snapshotter/resources/AWSClientFactory.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/resources/AWSClientFactory.scala
@@ -1,6 +1,7 @@
 package com.gu.flexible.snapshotter.resources
 
 import com.amazonaws.regions.Regions
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient
 import com.amazonaws.services.kinesis.AmazonKinesisClient
 import com.amazonaws.services.lambda.AWSLambdaClient
 import com.amazonaws.services.s3.AmazonS3Client
@@ -14,4 +15,6 @@ object AWSClientFactory {
     new AmazonS3Client().withRegion(region)
   def createLambdaClient(implicit region:Regions): AWSLambdaClient =
     new AWSLambdaClient().withRegion(region)
+  def createCloudwatchClient(implicit region:Regions): AmazonCloudWatchClient =
+    new AmazonCloudWatchClient().withRegion(region)
 }


### PR DESCRIPTION
Add basic CloudWatch metrics for number of snapshots processed and the number of failures that occur.

We then alert on it in https://github.com/guardian/editorial-tools-platform/pull/7
