### PR TITLE
Store summary data and metadata in a second file

### DIFF
--- a/src/main/scala/com/gu/flexible/snapshotter/SnapshottingLambda.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/SnapshottingLambda.scala
@@ -49,7 +49,7 @@ class SnapshottingLambda extends Logging {
       successfulApiResults.map{ snapshot =>
         val snapshotTime = new DateTime()
         val snapshotKey = makeKey(snapshot.id, snapshotTime, "json")
-        val snapshotSummaryKey = makeKey(snapshot.id, snapshotTime, "summary.json")
+        val snapshotSummaryKey = makeKey(snapshot.id, snapshotTime, "info.json")
         (
           uploadToS3Bucket(snapshotKey, snapshot.data),
           uploadToS3Bucket(snapshotSummaryKey, snapshot.summaryData)

--- a/src/main/scala/com/gu/flexible/snapshotter/config/Config.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/config/Config.scala
@@ -16,6 +16,18 @@ object Config {
     context.getFunctionName.split(Array('-','_')).toList.filter(_.length > 0).lastOption.getOrElse {
       throw new IllegalArgumentException(s"Couldn't guess stage from function name ${context.getFunctionName}")
     }
+
+  val defaultFieldsToExtract = List(
+    "preview.fields.headline",
+    "preview.settings.commentable",
+    "type",
+    "preview.settings.liveBloggingNow",
+    "preview.settings.legallySensitive",
+    "published",
+    "scheduledLaunchDate",
+    "preview.settings.embargoedUntil",
+    "contentChangeDetails.published"
+  ).map(_.split("\\.").toList)
 }
 
 object LambdaConfig {
@@ -38,4 +50,6 @@ trait CommonConfig {
 
   def contentUri = s"$apiUrl/content"
   def contentRawUri = s"$apiUrl/contentRaw"
+
+  def fieldsToExtract = Config.defaultFieldsToExtract
 }

--- a/src/main/scala/com/gu/flexible/snapshotter/logic/ApiLogic.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/logic/ApiLogic.scala
@@ -13,7 +13,7 @@ import scala.concurrent.ExecutionContext
 object ApiLogic extends Logging {
   def contentForSnapshot(snapshotRequest: SnapshotRequest)(implicit ws:WSClient, config:CommonConfig, context:ExecutionContext): Attempt[Snapshot] = {
     contentForId(snapshotRequest.contentId).map{ json =>
-      Snapshot(snapshotRequest.contentId, snapshotRequest.metadata, json)
+      Snapshot(snapshotRequest.contentId, snapshotRequest.metadata, json, config.fieldsToExtract)
     }
   }
 

--- a/src/main/scala/com/gu/flexible/snapshotter/logic/CloudWatchLogic.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/logic/CloudWatchLogic.scala
@@ -14,11 +14,13 @@ object MetricValue {
 case class MetricValue(value: Double, unit: String = MetricValue.None)
 
 object MetricName {
+  type MetricName = String
+
   // these keys are referenced in the cloudformation - don't change them!
-  val contentSnapshotError = "contentSnapshotError"
-  val contentSnapshotSuccess = "contentSnapshotSuccess"
-  val scheduledContentIdsError = "scheduledContentIdsError"
-  val scheduledContentIdsSuccess = "scheduledContentIdsSuccess"
+  val contentSnapshotError: MetricName = "contentSnapshotError"
+  val contentSnapshotSuccess: MetricName = "contentSnapshotSuccess"
+  val scheduledContentIdsError: MetricName = "scheduledContentIdsError"
+  val scheduledContentIdsSuccess: MetricName = "scheduledContentIdsSuccess"
 }
 
 object CloudWatchLogic extends Logging {

--- a/src/main/scala/com/gu/flexible/snapshotter/mainclasses/SnapshottingLambdaRunner.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/mainclasses/SnapshottingLambdaRunner.scala
@@ -7,10 +7,10 @@ import com.gu.flexible.snapshotter.logic.{FutureUtils, SNSLogic}
 import com.gu.flexible.snapshotter.model.{SnapshotMetadata, SnapshotRequest}
 
 object SnapshottingLambdaRunner extends App {
-  val bucket:String = ???
+  val bucket:String = "flexible-snapshotter-code"
 
   val sl = new SnapshottingLambda()
-  val input:Seq[String] = Seq(SNSLogic.serialise(SnapshotRequest("572dda3af7d0f2a7e4bbfb73", SnapshotMetadata("Testing"))))
+  val input:Seq[String] = Seq(SNSLogic.serialise(SnapshotRequest("57431375f7d04d8e107ab19e", SnapshotMetadata("Testing"))))
   val config = new SnapshotterConfig(
     bucket = bucket,
     stage = "DEV",

--- a/src/main/scala/com/gu/flexible/snapshotter/model/Snapshot.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/model/Snapshot.scala
@@ -1,10 +1,32 @@
 package com.gu.flexible.snapshotter.model
 
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json._
 
-case class Snapshot(id: String, snapshotMetadata: SnapshotMetadata, data: JsValue) {
-  lazy val snapshotDocument = Json.obj(
-    "data" -> data,
-    "metadata" -> snapshotMetadata
+import scala.language.postfixOps
+
+case class Snapshot(id: String, metadata: SnapshotMetadata, data: JsValue) {
+  val summaryData: JsObject = Json.obj(
+    "reason" -> JsString(metadata.reason)
+  ) ++ JsObject(Snapshot.fieldsToExtract.flatMap { field =>
+    Snapshot.extractField(data, field).map(field ->)
+  })
+}
+
+object Snapshot {
+  val fieldsToExtract = List(
+    "preview.fields.headline",
+    "preview.settings.commentable",
+    "type",
+    "preview.settings.liveBloggingNow",
+    "preview.settings.legallySensitive",
+    "published",
+    "scheduledLaunchDate",
+    "preview.settings.embargoedUntil"
   )
+
+  def extractField(json: JsLookup, field: String): Option[JsValue] = {
+    field.split("\\.").foldLeft(json) {
+      case (js, component) => js \ component
+    }.result.toOption
+  }
 }

--- a/src/main/scala/com/gu/flexible/snapshotter/model/Snapshot.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/model/Snapshot.scala
@@ -4,26 +4,14 @@ import play.api.libs.json._
 
 import scala.language.postfixOps
 
-case class Snapshot(id: String, metadata: SnapshotMetadata, data: JsValue) {
+case class Snapshot(id: String, metadata: SnapshotMetadata, data: JsValue, fieldsToExtract: List[List[String]]) {
   val summaryMetadata: JsObject = Json.obj("reason" -> JsString(metadata.reason))
-  val summaryFields: JsObject = Snapshot.fieldsToExtract.flatMap(Snapshot.soloField(data, _)).
+  val summaryFields: JsObject = fieldsToExtract.flatMap(Snapshot.soloField(data, _)).
     foldLeft(Json.obj())(_ deepMerge _)
   val summaryData: JsObject = Json.obj("metadata" -> summaryMetadata, "summary" -> summaryFields)
 }
 
 object Snapshot {
-  val fieldsToExtract = List(
-    "preview.fields.headline",
-    "preview.settings.commentable",
-    "type",
-    "preview.settings.liveBloggingNow",
-    "preview.settings.legallySensitive",
-    "published",
-    "scheduledLaunchDate",
-    "preview.settings.embargoedUntil",
-    "contentChangeDetails.published"
-  ).map(_.split("\\.").toList)
-
   def soloField(json: JsLookup, field: List[String]): Option[JsObject] = {
     field match {
       case head :: Nil => (json \ head).toOption.map(obj => Json.obj(head -> obj))

--- a/src/main/scala/com/gu/flexible/snapshotter/model/Snapshot.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/model/Snapshot.scala
@@ -6,7 +6,8 @@ import scala.language.postfixOps
 
 case class Snapshot(id: String, metadata: SnapshotMetadata, data: JsValue) {
   val summaryMetadata: JsObject = Json.obj("reason" -> JsString(metadata.reason))
-  val summaryFields: JsObject = Snapshot.fieldsToExtract.flatMap(Snapshot.soloField(data, _)).foldLeft(Json.obj())(_++_)
+  val summaryFields: JsObject = Snapshot.fieldsToExtract.flatMap(Snapshot.soloField(data, _)).
+    foldLeft(Json.obj())(_ deepMerge _)
   val summaryData: JsObject = Json.obj("metadata" -> summaryMetadata, "summary" -> summaryFields)
 }
 

--- a/src/main/scala/com/gu/flexible/snapshotter/model/Snapshot.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/model/Snapshot.scala
@@ -21,9 +21,9 @@ object Snapshot {
     "scheduledLaunchDate",
     "preview.settings.embargoedUntil",
     "contentChangeDetails.published"
-  ).map(_.split("\\.").toSeq)
+  ).map(_.split("\\.").toList)
 
-  def soloField(json: JsLookup, field: Seq[String]): Option[JsObject] = {
+  def soloField(json: JsLookup, field: List[String]): Option[JsObject] = {
     field match {
       case head :: Nil => (json \ head).toOption.map(obj => Json.obj(head -> obj))
       case head :: tail => soloField(json \ head, tail).map(obj => Json.obj(head -> obj))

--- a/src/test/scala/com/gu/flexible/snapshotter/logic/SnapshotSpec.scala
+++ b/src/test/scala/com/gu/flexible/snapshotter/logic/SnapshotSpec.scala
@@ -1,6 +1,6 @@
 package com.gu.flexible.snapshotter.logic
 
-import com.gu.flexible.snapshotter.model.Snapshot
+import com.gu.flexible.snapshotter.model.{Snapshot, SnapshotMetadata}
 import org.scalatest.{FlatSpec, ShouldMatchers}
 import play.api.libs.json.{JsBoolean, JsObject, JsString, Json}
 
@@ -8,7 +8,11 @@ class SnapshotSpec extends FlatSpec with ShouldMatchers {
   val testJson = Json.obj(
     "test1" -> Json.obj(
       "field1a" -> JsString("bubbles"),
-      "field1b" -> JsString("bubbling")
+      "field1b" -> JsString("bubbling"),
+      "field1C" -> Json.obj(
+        "subField1a" -> JsString("monkey"),
+        "subField1b" -> JsString("monkeys")
+      )
     ),
     "test2" -> Json.obj(
       "field2a" -> JsBoolean(true),
@@ -27,12 +31,35 @@ class SnapshotSpec extends FlatSpec with ShouldMatchers {
   }
 
   it should "return a subtree if the path ends with an object" in {
-    val result = Snapshot.soloField(testJson, List("test1"))
+    val result = Snapshot.soloField(testJson, List("test2"))
     result should be(Some(Json.obj(
-      "test1" -> Json.obj(
-        "field1a" -> JsString("bubbles"),
-        "field1b" -> JsString("bubbling")
+      "test2" -> Json.obj(
+        "field2a" -> JsBoolean(true),
+        "field2b" -> JsBoolean(false)
       )
     )))
+  }
+
+  "Snapshot" should "extract a number of fields" in {
+    val snapshot = Snapshot("test", SnapshotMetadata("reason!"), testJson,
+      List(
+        List("test1", "field1a"),
+        List("test2", "field2b"),
+        List("test1", "field1C", "subField1a"),
+        List("unknown"),
+        List("test1", "unknown")
+      )
+    )
+    snapshot.summaryFields should be(Json.obj(
+      "test1" -> Json.obj(
+        "field1a" -> JsString("bubbles"),
+        "field1C" -> Json.obj(
+          "subField1a" -> JsString("monkey")
+        )
+      ),
+      "test2" -> Json.obj(
+        "field2b" -> JsBoolean(false)
+      )
+    ))
   }
 }

--- a/src/test/scala/com/gu/flexible/snapshotter/logic/SnapshotSpec.scala
+++ b/src/test/scala/com/gu/flexible/snapshotter/logic/SnapshotSpec.scala
@@ -2,46 +2,37 @@ package com.gu.flexible.snapshotter.logic
 
 import com.gu.flexible.snapshotter.model.Snapshot
 import org.scalatest.{FlatSpec, ShouldMatchers}
-import play.api.libs.json.{JsBoolean, JsString, Json}
+import play.api.libs.json.{JsBoolean, JsObject, JsString, Json}
 
 class SnapshotSpec extends FlatSpec with ShouldMatchers {
-  "extractField" should "return a value from a json tree" in {
-    val testJson = Json.obj(
-      "test" -> Json.obj(
-        "field" -> JsString("bubbles")
-      )
+  val testJson = Json.obj(
+    "test1" -> Json.obj(
+      "field1a" -> JsString("bubbles"),
+      "field1b" -> JsString("bubbling")
+    ),
+    "test2" -> Json.obj(
+      "field2a" -> JsBoolean(true),
+      "field2b" -> JsBoolean(false)
     )
-    val result = Snapshot.extractField(testJson, "test.field")
-    result should be(Some(JsString("bubbles")))
+  )
+
+  "soloField" should "extract a single field from a tree" in {
+    val result = Snapshot.soloField(testJson, Seq("test1", "field1a"))
+    result should be(Some(Json.obj("test1" -> Json.obj("field1a" -> JsString("bubbles")))))
   }
 
-  it should "return none when the field is missing" in {
-    val testJson = Json.obj(
-      "test" -> Json.obj(
-        "field" -> JsString("bubbles")
-      )
-    )
-    val result = Snapshot.extractField(testJson, "test.field2")
+  it should "return none if part of the path doesn't exist" in {
+    val result = Snapshot.soloField(testJson, Seq("test3", "field1a"))
     result should be(None)
   }
 
-  it should "return none when the object is missing" in {
-    val testJson = Json.obj(
-      "test" -> Json.obj(
-        "field" -> JsString("bubbles")
+  it should "return a subtree if the path ends with an object" in {
+    val result = Snapshot.soloField(testJson, Seq("test1"))
+    result should be(Some(Json.obj(
+      "test1" -> Json.obj(
+        "field1a" -> JsString("bubbles"),
+        "field1b" -> JsString("bubbling")
       )
-    )
-    val result = Snapshot.extractField(testJson, "test2.field")
-    result should be(None)
-  }
-
-  it should "return something when the field is a boolean" in {
-    val testJson = Json.obj(
-      "test" -> Json.obj(
-        "field" -> JsBoolean(true)
-      )
-    )
-    val result = Snapshot.extractField(testJson, "test.field")
-    result should be(Some(JsBoolean(true)))
+    )))
   }
 }

--- a/src/test/scala/com/gu/flexible/snapshotter/logic/SnapshotSpec.scala
+++ b/src/test/scala/com/gu/flexible/snapshotter/logic/SnapshotSpec.scala
@@ -1,0 +1,47 @@
+package com.gu.flexible.snapshotter.logic
+
+import com.gu.flexible.snapshotter.model.Snapshot
+import org.scalatest.{FlatSpec, ShouldMatchers}
+import play.api.libs.json.{JsBoolean, JsString, Json}
+
+class SnapshotSpec extends FlatSpec with ShouldMatchers {
+  "extractField" should "return a value from a json tree" in {
+    val testJson = Json.obj(
+      "test" -> Json.obj(
+        "field" -> JsString("bubbles")
+      )
+    )
+    val result = Snapshot.extractField(testJson, "test.field")
+    result should be(Some(JsString("bubbles")))
+  }
+
+  it should "return none when the field is missing" in {
+    val testJson = Json.obj(
+      "test" -> Json.obj(
+        "field" -> JsString("bubbles")
+      )
+    )
+    val result = Snapshot.extractField(testJson, "test.field2")
+    result should be(None)
+  }
+
+  it should "return none when the object is missing" in {
+    val testJson = Json.obj(
+      "test" -> Json.obj(
+        "field" -> JsString("bubbles")
+      )
+    )
+    val result = Snapshot.extractField(testJson, "test2.field")
+    result should be(None)
+  }
+
+  it should "return something when the field is a boolean" in {
+    val testJson = Json.obj(
+      "test" -> Json.obj(
+        "field" -> JsBoolean(true)
+      )
+    )
+    val result = Snapshot.extractField(testJson, "test.field")
+    result should be(Some(JsBoolean(true)))
+  }
+}

--- a/src/test/scala/com/gu/flexible/snapshotter/logic/SnapshotSpec.scala
+++ b/src/test/scala/com/gu/flexible/snapshotter/logic/SnapshotSpec.scala
@@ -17,17 +17,17 @@ class SnapshotSpec extends FlatSpec with ShouldMatchers {
   )
 
   "soloField" should "extract a single field from a tree" in {
-    val result = Snapshot.soloField(testJson, Seq("test1", "field1a"))
+    val result = Snapshot.soloField(testJson, List("test1", "field1a"))
     result should be(Some(Json.obj("test1" -> Json.obj("field1a" -> JsString("bubbles")))))
   }
 
   it should "return none if part of the path doesn't exist" in {
-    val result = Snapshot.soloField(testJson, Seq("test3", "field1a"))
+    val result = Snapshot.soloField(testJson, List("test3", "field1a"))
     result should be(None)
   }
 
   it should "return a subtree if the path ends with an object" in {
-    val result = Snapshot.soloField(testJson, Seq("test1"))
+    val result = Snapshot.soloField(testJson, List("test1"))
     result should be(Some(Json.obj(
       "test1" -> Json.obj(
         "field1a" -> JsString("bubbles"),


### PR DESCRIPTION
Whilst working on making the restorer **better** (https://github.com/guardian/flexible-restorer/pull/5) it became clear that having easier access to metadata and certain useful fields will make everything a whole lot easier. Rather than storing it in the main JSON block we can store it as a separate summary file (which we can retrieve more easily).
