### PR TITLE
Add revision to summary fields

### DIFF
--- a/src/main/scala/com/gu/flexible/snapshotter/config/Config.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/config/Config.scala
@@ -26,7 +26,8 @@ object Config {
     "published",
     "scheduledLaunchDate",
     "preview.settings.embargoedUntil",
-    "contentChangeDetails.published"
+    "contentChangeDetails.published",
+    "contentChangeDetails.revision"
   ).map(_.split("\\.").toList)
 }
 


### PR DESCRIPTION
We will display the revision rather than a generated ID if it has been collected during snapshotting.
