### PR TITLE
GDPR fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.idea

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ scalacOptions ++= Seq(
   "-Ywarn-unused-import")
 
 val awsVersion = "1.11.5"
-val playVersion = "2.5.0"
+val playVersion = "2.5.18"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,9 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-sns" % awsVersion,
   "com.typesafe.play" %% "play-json" % playVersion,
   "com.typesafe.play" %% "play-ws" % playVersion,
-  "org.scalatest" %% "scalatest" % "2.2.5" % "test"
+  "org.scalatest" %% "scalatest" % "2.2.5" % "test",
+  // This is required to force aws libraries to use the latest version of jackson
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.2"
 )
 
 publishMavenStyle := false

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ scalacOptions ++= Seq(
   "-unchecked",
   "-Ywarn-unused-import")
 
-val awsVersion = "1.11.5"
+val awsVersion = "1.11.234"
 val playVersion = "2.5.18"
 
 libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -3,10 +3,14 @@ import com.typesafe.sbt.packager.archetypes.JavaAppPackaging._
 name := "snapshotter-lambda"
 organization  := "com.gu"
 
-scalaVersion in ThisBuild := "2.11.8"
+scalaVersion in ThisBuild := "2.11.11"
 
 description   := "AWS lambdas to snapshot Flexible content to S3"
-scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked")
+scalacOptions ++= Seq(
+  "-deprecation",
+  "-feature",
+  "-unchecked",
+  "-Ywarn-unused-import")
 
 val awsVersion = "1.11.5"
 val playVersion = "2.5.0"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,7 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.0")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.7")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.5.3")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")

--- a/src/main/scala/com/gu/flexible/snapshotter/SchedulingLambda.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/SchedulingLambda.scala
@@ -3,7 +3,7 @@ package com.gu.flexible.snapshotter
 import java.util.{Map => JMap}
 
 import com.amazonaws.regions.Regions
-import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.sns.model.PublishResult
 import com.gu.flexible.snapshotter.config.{CommonConfig, Config, SchedulerConfig}
@@ -63,7 +63,7 @@ class SchedulingLambda extends Logging {
 
 object SchedulingLambda extends Logging {
   def logResult(result: Attempt[Seq[PublishResult]])
-    (implicit cloudWatchClient:AmazonCloudWatchClient, config: CommonConfig): Future[Unit] = {
+    (implicit cloudWatchClient:AmazonCloudWatch, config: CommonConfig): Future[Unit] = {
     result.fold(
       { errors =>
         errors.errors.foreach(_.logTo(log))

--- a/src/main/scala/com/gu/flexible/snapshotter/SchedulingLambda.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/SchedulingLambda.scala
@@ -15,7 +15,6 @@ import play.api.libs.ws.WSClient
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.language.postfixOps
 
 class SchedulingLambda extends Logging {
   import ApiLogic._

--- a/src/main/scala/com/gu/flexible/snapshotter/SnapshottingLambda.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/SnapshottingLambda.scala
@@ -13,7 +13,6 @@ import org.joda.time.DateTime
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.language.postfixOps
 
 class SnapshottingLambda extends Logging {
   import ApiLogic._

--- a/src/main/scala/com/gu/flexible/snapshotter/SnapshottingLambda.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/SnapshottingLambda.scala
@@ -1,7 +1,7 @@
 package com.gu.flexible.snapshotter
 
 import com.amazonaws.regions.Regions
-import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.SNSEvent
 import com.amazonaws.services.s3.model.PutObjectResult
@@ -68,7 +68,7 @@ object SnapshottingLambda extends Logging {
   import MetricName._
 
   def logResults(results: Attempt[Seq[(Attempt[PutObjectResult],Attempt[PutObjectResult])]])
-    (implicit cloudWatchClient:AmazonCloudWatchClient, config: CommonConfig): Future[Unit] = {
+    (implicit cloudWatchClient:AmazonCloudWatch, config: CommonConfig): Future[Unit] = {
     results.fold(
       { failed =>
         CloudWatchLogic.putMetricData(
@@ -86,7 +86,7 @@ object SnapshottingLambda extends Logging {
   }
 
   def logResultsAttempts(succeeded: Seq[Attempt[PutObjectResult]], successMetric: Option[MetricName] = None,
-    failureMetric: Option[MetricName] = None)(implicit cloudWatchClient:AmazonCloudWatchClient, config: CommonConfig): Future[Unit] = {
+    failureMetric: Option[MetricName] = None)(implicit cloudWatchClient:AmazonCloudWatch, config: CommonConfig): Future[Unit] = {
     Future.sequence(succeeded.map(_.asFuture)).map { attempts =>
       attempts.foreach {
         case Left(failures) =>

--- a/src/main/scala/com/gu/flexible/snapshotter/config/Config.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/config/Config.scala
@@ -1,6 +1,6 @@
 package com.gu.flexible.snapshotter.config
 
-import com.amazonaws.regions.{Region, Regions}
+import com.amazonaws.regions.Region
 import com.amazonaws.services.lambda.AWSLambdaClient
 import com.amazonaws.services.lambda.model.GetFunctionConfigurationRequest
 import com.amazonaws.services.lambda.runtime.Context

--- a/src/main/scala/com/gu/flexible/snapshotter/config/Config.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/config/Config.scala
@@ -1,7 +1,7 @@
 package com.gu.flexible.snapshotter.config
 
 import com.amazonaws.regions.Region
-import com.amazonaws.services.lambda.AWSLambdaClient
+import com.amazonaws.services.lambda.AWSLambda
 import com.amazonaws.services.lambda.model.GetFunctionConfigurationRequest
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.flexible.snapshotter.Logging
@@ -31,7 +31,7 @@ object Config {
 }
 
 object LambdaConfig extends Logging {
-  def getDescriptionJson(context: Context)(implicit lambdaClient: AWSLambdaClient) = {
+  def getDescriptionJson(context: Context)(implicit lambdaClient: AWSLambda) = {
     val functionMetadata = lambdaClient.getFunctionConfiguration(
       new GetFunctionConfigurationRequest()
         .withFunctionName(context.getFunctionName)

--- a/src/main/scala/com/gu/flexible/snapshotter/config/SchedulerConfig.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/config/SchedulerConfig.scala
@@ -4,7 +4,7 @@ import com.amazonaws.regions.{Region, Regions}
 import com.amazonaws.services.lambda.AWSLambdaClient
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.flexible.snapshotter.Logging
-import play.api.libs.json.{Json, Reads}
+import play.api.libs.json.Json
 
 object LambdaSchedulerConfig {
   implicit val configReads = Json.reads[LambdaSchedulerConfig]

--- a/src/main/scala/com/gu/flexible/snapshotter/config/SchedulerConfig.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/config/SchedulerConfig.scala
@@ -1,7 +1,7 @@
 package com.gu.flexible.snapshotter.config
 
 import com.amazonaws.regions.{Region, Regions}
-import com.amazonaws.services.lambda.AWSLambdaClient
+import com.amazonaws.services.lambda.AWSLambda
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.flexible.snapshotter.Logging
 import play.api.libs.json.Json
@@ -18,7 +18,7 @@ case class SchedulerConfig(
   region: Region = Regions.getCurrentRegion) extends CommonConfig
 
 object SchedulerConfig extends Logging {
-  def resolve(stage: String, context: Context)(implicit lambdaClient: AWSLambdaClient): SchedulerConfig = {
+  def resolve(stage: String, context: Context)(implicit lambdaClient: AWSLambda): SchedulerConfig = {
     val lambdaJson = LambdaConfig.getDescriptionJson(context)
     val lambdaConfig = lambdaJson.as[LambdaSchedulerConfig]
     SchedulerConfig(

--- a/src/main/scala/com/gu/flexible/snapshotter/config/SnapshotterConfig.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/config/SnapshotterConfig.scala
@@ -1,7 +1,7 @@
 package com.gu.flexible.snapshotter.config
 
 import com.amazonaws.regions.{Region, Regions}
-import com.amazonaws.services.lambda.AWSLambdaClient
+import com.amazonaws.services.lambda.AWSLambda
 import com.amazonaws.services.lambda.runtime.Context
 import play.api.libs.json.Json
 
@@ -18,7 +18,7 @@ case class SnapshotterConfig(
   region: Region = Regions.getCurrentRegion) extends CommonConfig
 
 object SnapshotterConfig {
-  def resolve(stage: String, context: Context)(implicit lambdaClient: AWSLambdaClient): SnapshotterConfig = {
+  def resolve(stage: String, context: Context)(implicit lambdaClient: AWSLambda): SnapshotterConfig = {
     val lambdaJson = LambdaConfig.getDescriptionJson(context)
     val lambdaConfig = lambdaJson.as[LambdaSnapshotterConfig]
     SnapshotterConfig(

--- a/src/main/scala/com/gu/flexible/snapshotter/logic/CloudWatchLogic.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/logic/CloudWatchLogic.scala
@@ -1,6 +1,6 @@
 package com.gu.flexible.snapshotter.logic
 
-import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest, StandardUnit}
 import com.gu.flexible.snapshotter.Logging
 import com.gu.flexible.snapshotter.config.CommonConfig
@@ -28,7 +28,7 @@ object CloudWatchLogic extends Logging {
     dimensions.map{ case (name, value) => new Dimension().withName(name).withValue(value) }
   }
 
-  def putMetricData(metrics: (String, MetricValue)*)(implicit cloudWatchClient: AmazonCloudWatchClient, config: CommonConfig) = {
+  def putMetricData(metrics: (String, MetricValue)*)(implicit cloudWatchClient: AmazonCloudWatch, config: CommonConfig) = {
     val dimensions = awsDimensions(config.cloudWatchDimensions:_*)
     val metricData = metrics.map { case (name, value) =>
       new MetricDatum().withMetricName(name).withUnit(value.unit).withValue(value.value).withDimensions(dimensions:_*)

--- a/src/main/scala/com/gu/flexible/snapshotter/logic/S3Logic.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/logic/S3Logic.scala
@@ -3,7 +3,7 @@ package com.gu.flexible.snapshotter.logic
 import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
 
-import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.{ObjectMetadata, PutObjectRequest, PutObjectResult, SSEAwsKeyManagementParams}
 import com.amazonaws.{AmazonClientException, AmazonServiceException}
 import com.gu.flexible.snapshotter.Logging
@@ -15,13 +15,13 @@ import play.api.libs.json.{JsValue, Json}
 
 object S3Logic extends Logging {
   def uploadToS3Bucket(id: String, date: DateTime, content: JsValue)
-    (implicit s3Client: AmazonS3Client, config: SnapshotterConfig): Attempt[PutObjectResult] = {
+    (implicit s3Client: AmazonS3, config: SnapshotterConfig): Attempt[PutObjectResult] = {
     val key = makeKey(id, date, extension = "json")
     uploadToS3Bucket(key, content)
   }
 
   def uploadToS3Bucket(key: String, content: JsValue)
-    (implicit s3Client: AmazonS3Client, config: SnapshotterConfig): Attempt[PutObjectResult] = {
+    (implicit s3Client: AmazonS3, config: SnapshotterConfig): Attempt[PutObjectResult] = {
     val jsonBytes = Json.prettyPrint(content).getBytes(StandardCharsets.UTF_8)
 
     val objectMetadata = new ObjectMetadata()

--- a/src/main/scala/com/gu/flexible/snapshotter/logic/SNSLogic.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/logic/SNSLogic.scala
@@ -1,7 +1,7 @@
 package com.gu.flexible.snapshotter.logic
 
 import com.amazonaws.services.lambda.runtime.events.SNSEvent
-import com.amazonaws.services.sns.AmazonSNSClient
+import com.amazonaws.services.sns.AmazonSNS
 import com.amazonaws.services.sns.model.{PublishRequest, PublishResult}
 import com.gu.flexible.snapshotter.Logging
 import com.gu.flexible.snapshotter.model.{Attempt, AttemptError, AttemptErrors}
@@ -34,7 +34,7 @@ object SNSLogic extends Logging {
     }
   }
 
-  def publish(topicArn: String, message: String)(implicit client: AmazonSNSClient): PublishResult = {
+  def publish(topicArn: String, message: String)(implicit client: AmazonSNS): PublishResult = {
     log.info(s"Sending to SNS: $message")
     val result = client.publish(
       new PublishRequest().

--- a/src/main/scala/com/gu/flexible/snapshotter/mainclasses/SchedulingLambdaRunner.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/mainclasses/SchedulingLambdaRunner.scala
@@ -2,7 +2,7 @@ package com.gu.flexible.snapshotter.mainclasses
 
 import com.amazonaws.regions.{Region, Regions}
 import com.gu.flexible.snapshotter.SchedulingLambda
-import com.gu.flexible.snapshotter.config.{Config, SchedulerConfig}
+import com.gu.flexible.snapshotter.config.SchedulerConfig
 import com.gu.flexible.snapshotter.logic.FutureUtils
 
 object SchedulingLambdaRunner extends App {

--- a/src/main/scala/com/gu/flexible/snapshotter/model/Snapshot.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/model/Snapshot.scala
@@ -2,7 +2,6 @@ package com.gu.flexible.snapshotter.model
 
 import play.api.libs.json._
 
-import scala.language.postfixOps
 
 case class Snapshot(id: String, metadata: SnapshotMetadata, data: JsValue, fieldsToExtract: List[List[String]]) {
   val summaryMetadata: JsObject = Json.obj("reason" -> JsString(metadata.reason))

--- a/src/main/scala/com/gu/flexible/snapshotter/resources/AWSClientFactory.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/resources/AWSClientFactory.scala
@@ -1,20 +1,20 @@
 package com.gu.flexible.snapshotter.resources
 
 import com.amazonaws.regions.Regions
-import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient
-import com.amazonaws.services.lambda.AWSLambdaClient
-import com.amazonaws.services.s3.AmazonS3Client
-import com.amazonaws.services.sns.AmazonSNSClient
+import com.amazonaws.services.cloudwatch.{AmazonCloudWatch, AmazonCloudWatchClientBuilder}
+import com.amazonaws.services.lambda.{AWSLambda, AWSLambdaClientBuilder}
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
+import com.amazonaws.services.sns.{AmazonSNS, AmazonSNSClientBuilder}
 
 object AWSClientFactory {
   def getRegion = Option(System.getenv("AWS_DEFAULT_REGION")).map(Regions.fromName).get
 
-  def createSNSClient(implicit region:Regions): AmazonSNSClient =
-    new AmazonSNSClient().withRegion(region)
-  def createS3Client(implicit region:Regions): AmazonS3Client =
-    new AmazonS3Client().withRegion(region)
-  def createLambdaClient(implicit region:Regions): AWSLambdaClient =
-    new AWSLambdaClient().withRegion(region)
-  def createCloudwatchClient(implicit region:Regions): AmazonCloudWatchClient =
-    new AmazonCloudWatchClient().withRegion(region)
+  def createSNSClient(implicit region:Regions): AmazonSNS =
+    AmazonSNSClientBuilder.standard().withRegion(region.getName).build()
+  def createS3Client(implicit region:Regions): AmazonS3 =
+    AmazonS3ClientBuilder.standard().withRegion(region.getName).build()
+  def createLambdaClient(implicit region:Regions): AWSLambda =
+    AWSLambdaClientBuilder.standard().withRegion(region.getName).build()
+  def createCloudwatchClient(implicit region:Regions): AmazonCloudWatch =
+    AmazonCloudWatchClientBuilder.standard().withRegion(region.getName).build()
 }

--- a/src/test/scala/com/gu/flexible/snapshotter/logic/SnapshotSpec.scala
+++ b/src/test/scala/com/gu/flexible/snapshotter/logic/SnapshotSpec.scala
@@ -2,7 +2,7 @@ package com.gu.flexible.snapshotter.logic
 
 import com.gu.flexible.snapshotter.model.{Snapshot, SnapshotMetadata}
 import org.scalatest.{FlatSpec, ShouldMatchers}
-import play.api.libs.json.{JsBoolean, JsObject, JsString, Json}
+import play.api.libs.json.{JsBoolean, JsString, Json}
 
 class SnapshotSpec extends FlatSpec with ShouldMatchers {
   val testJson = Json.obj(


### PR DESCRIPTION
- Add scalafix
- Remove unused imports
- bump scala, play, and aws versions
- After moving to latest aws version change how clients are created so deprecated methods are no longer used