### PR TITLE
if secondary, go direct to postgres

### DIFF
--- a/src/main/scala/com/gu/flexible/snapshotter/config/Config.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/config/Config.scala
@@ -11,7 +11,7 @@ object Config {
   def apiUrl(stage: String, stack: String): String = {
     val subDomain = stack match {
       case "flexible-secondary" => "apiv2" // we're not running a proxy (or mongo) in secondary, go direct to postgres
-      case _ => "flexible-content-api-proxy"
+      case _ => "flexible-api"
     }
 
     s"http://$subDomain.${stage.toLowerCase}.${stack.toLowerCase}.gudiscovery.:8080"

--- a/src/main/scala/com/gu/flexible/snapshotter/config/Config.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/config/Config.scala
@@ -8,7 +8,14 @@ import com.gu.flexible.snapshotter.Logging
 import play.api.libs.json.Json
 
 object Config {
-  def apiUrl(stage: String, stack: String): String = s"http://flexible-content-api-proxy.${stage.toLowerCase}.${stack.toLowerCase}.gudiscovery.:8080"
+  def apiUrl(stage: String, stack: String): String = {
+    val subDomain = stack match {
+      case "flexible-secondary" => "apiv2" // we're not running a proxy (or mongo) in secondary, go direct to postgres
+      case _ => "flexible-content-api-proxy"
+    }
+
+    s"http://$subDomain.${stage.toLowerCase}.${stack.toLowerCase}.gudiscovery.:8080"
+  }
 
   def guessStage(context: Context): String =
     context.getFunctionName.split(Array('-','_')).toList.filter(_.length > 0).lastOption.getOrElse {


### PR DESCRIPTION
We're not running a proxy (or mongo) in secondary. Go direct to Postgres. Do not pass Go. Do not collect £200.

![](https://media.giphy.com/media/3oz8xsuGvBn03H1boY/giphy.gif)