### PR TITLE
Bump aws-lambda-java-log4j2 to 1.5.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
   "com.amazonaws" % "aws-lambda-java-events" % "1.1.0" intransitive(),
   "com.amazonaws" % "aws-lambda-java-log4j2" % "1.5.0",
+  "org.slf4j" % "slf4j-log4j12" % "1.7.32",
   "net.logstash.log4j" % "jsonevent-layout" % "1.7",
   "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-lambda" % awsVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,8 @@ val playVersion = "1.1.2"
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
   "com.amazonaws" % "aws-lambda-java-events" % "1.1.0" intransitive(),
-  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.5.0",
-  "org.slf4j" % "slf4j-log4j12" % "1.7.32",
+  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.5.1",
+  "org.slf4j" % "slf4j-simple" % "1.7.32",
   "net.logstash.log4j" % "jsonevent-layout" % "1.7",
   "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-lambda" % awsVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,7 @@ val playVersion = "1.1.2"
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
   "com.amazonaws" % "aws-lambda-java-events" % "1.1.0" intransitive(),
-  "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.0",
-  "org.slf4j" % "slf4j-log4j12" % "1.7.21",
+  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.5.0",
   "net.logstash.log4j" % "jsonevent-layout" % "1.7",
   "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-lambda" % awsVersion,

--- a/src/main/scala/com/gu/flexible/snapshotter/SchedulingLambda.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/SchedulingLambda.scala
@@ -10,7 +10,6 @@ import com.gu.flexible.snapshotter.config.{CommonConfig, Config, SchedulerConfig
 import com.gu.flexible.snapshotter.logic._
 import com.gu.flexible.snapshotter.model.{Attempt, SnapshotMetadata, SnapshotRequest}
 import com.gu.flexible.snapshotter.resources.{AWSClientFactory, WSClientFactory}
-import org.apache.log4j.LogManager
 import play.api.libs.ws.StandaloneWSClient
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -54,7 +53,6 @@ class SchedulingLambda extends Logging {
   }
 
   def shutdown() = {
-    LogManager.shutdown()
     snsClient.shutdown()
     lambdaClient.shutdown()
     wsClient.close()

--- a/src/main/scala/com/gu/flexible/snapshotter/mainclasses/FakeContext.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/mainclasses/FakeContext.scala
@@ -11,6 +11,7 @@ class FakeContext extends Context {
 
   val logger = new LambdaLogger {
     def log(string: String): Unit = System.out.println(string)
+    def log(bytes: Array[Byte]): Unit = System.out.println(bytes)
   }
   def getLogger: LambdaLogger = logger
 


### PR DESCRIPTION
## What does this change?

Bumps aws-lambda-java-log4j2 to 1.5.1.

Matching [flexible-octopus-converter](https://github.com/guardian/flexible-octopus-converter), I've used slf4j-simple to provide the slf4j interface, which seems to delegate to log4j without specifying a version (log4j12 looks hardcoded to 1.2.x).

## How to test

Deploy to CODE and create a snapshot (perhaps by publishing an article, which IIUC should ping snapshotter). The process should work as expected, and you should see logs from flexible-snapshotter in ELK.

Running `sbt dependencyTree | grep log4j` should only yield >= `v2.17.0`.

Tested in CODE with [this content](https://composer.code.dev-gutools.co.uk/content/61d468ac8f08f06c88724334), snapshots yielded as usual with [accompanying logs](https://logs.gutools.co.uk/s/editorial-tools/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_a=(columns:!(message),filters:!(),index:'67604290-baa6-11e9-bea2-633437abb232',interval:auto,query:(language:lucene,query:'app:%22snapshotter%22%20AND%20stage:CODE'),sort:!())).