### PR TITLE
Remove log4j

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,6 @@ val playVersion = "1.1.2"
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
   "com.amazonaws" % "aws-lambda-java-events" % "1.1.0" intransitive(),
-  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.5.1",
   "org.slf4j" % "slf4j-simple" % "1.7.32",
   "net.logstash.log4j" % "jsonevent-layout" % "1.7",
   "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,8 +1,0 @@
-log=.
-log4j.rootLogger=INFO,LAMBDA
-
-log4j.logger.io.netty=WARN,LAMBDA
-
-#Define the LAMBDA appender
-log4j.appender.LAMBDA=com.amazonaws.services.lambda.runtime.log4j.LambdaAppender
-log4j.appender.LAMBDA.layout=net.logstash.log4j.JSONEventLayoutV1

--- a/src/main/resources/simplelogger.properties
+++ b/src/main/resources/simplelogger.properties
@@ -1,0 +1,2 @@
+org.slf4j.simpleLogger.showThreadName=false
+org.slf4j.simpleLogger.levelInBrackets=true


### PR DESCRIPTION
## What does this change?

In line with the approach taken with [other](https://github.com/guardian/rcs-poller-lambda/pull/36) [lambdas](https://github.com/guardian/production-metrics-lambdas/pull/9), removes log4j entirely in favour of slf4j-simple. We lose line numbers in logs, but the simpler approach leaves us less vulnerable to log4j exploits.

## How to test

Deploy to CODE and create a snapshot (perhaps by publishing an article, which will ping snapshotter). The process should work as expected, and you should see logs from flexible-snapshotter in ELK.

Running sbt dependencyTree | grep log4j should only yield >= v2.17.0.
