### PR TITLE
Upgrade aws sdk to latest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ scalacOptions ++= Seq(
   "-unchecked",
   "-Ywarn-unused-import")
 
-val awsVersion = "1.11.234"
+val awsVersion = "1.12.148"
 val playVersion = "1.1.2"
 
 libraryDependencies ++= Seq(

--- a/src/main/scala/com/gu/flexible/snapshotter/config/Config.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/config/Config.scala
@@ -1,6 +1,5 @@
 package com.gu.flexible.snapshotter.config
 
-import com.amazonaws.regions.Region
 import com.amazonaws.services.lambda.AWSLambda
 import com.amazonaws.services.lambda.model.GetFunctionConfigurationRequest
 import com.amazonaws.services.lambda.runtime.Context
@@ -48,7 +47,6 @@ object LambdaConfig extends Logging {
 }
 
 trait CommonConfig {
-  def region: Region
   def cloudWatchNameSpace: String = "SnapshotterLambdas"
   def cloudWatchDimensions: Seq[(String,String)] = Seq("Stage" -> stage)
   def stage: String

--- a/src/main/scala/com/gu/flexible/snapshotter/config/SchedulerConfig.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/config/SchedulerConfig.scala
@@ -1,6 +1,5 @@
 package com.gu.flexible.snapshotter.config
 
-import com.amazonaws.regions.{Region, Regions}
 import com.amazonaws.services.lambda.AWSLambda
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.flexible.snapshotter.Logging
@@ -14,8 +13,7 @@ case class LambdaSchedulerConfig(snsTopicArn: String, stack: String)
 case class SchedulerConfig(
   snsTopicArn: String,
   stage: String,
-  stack: String,
-  region: Region = Regions.getCurrentRegion) extends CommonConfig
+  stack: String) extends CommonConfig
 
 object SchedulerConfig extends Logging {
   def resolve(stage: String, context: Context)(implicit lambdaClient: AWSLambda): SchedulerConfig = {

--- a/src/main/scala/com/gu/flexible/snapshotter/config/SnapshotterConfig.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/config/SnapshotterConfig.scala
@@ -1,6 +1,5 @@
 package com.gu.flexible.snapshotter.config
 
-import com.amazonaws.regions.{Region, Regions}
 import com.amazonaws.services.lambda.AWSLambda
 import com.amazonaws.services.lambda.runtime.Context
 import play.api.libs.json.Json
@@ -14,8 +13,7 @@ case class SnapshotterConfig(
   bucket: String,
   stage: String,
   stack: String,
-  kmsKey: Option[String] = None,
-  region: Region = Regions.getCurrentRegion) extends CommonConfig
+  kmsKey: Option[String] = None) extends CommonConfig
 
 object SnapshotterConfig {
   def resolve(stage: String, context: Context)(implicit lambdaClient: AWSLambda): SnapshotterConfig = {

--- a/src/main/scala/com/gu/flexible/snapshotter/mainclasses/SchedulingLambdaRunner.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/mainclasses/SchedulingLambdaRunner.scala
@@ -1,6 +1,5 @@
 package com.gu.flexible.snapshotter.mainclasses
 
-import com.amazonaws.regions.{Region, Regions}
 import com.gu.flexible.snapshotter.SchedulingLambda
 import com.gu.flexible.snapshotter.config.SchedulerConfig
 import com.gu.flexible.snapshotter.logic.FutureUtils
@@ -14,8 +13,7 @@ object SchedulingLambdaRunner extends App {
   implicit val config = new SchedulerConfig(
     snsTopicArn = snsTopicArn,
     stack = stack,
-    stage = "DEV",
-    region = Region.getRegion(Regions.EU_WEST_1)
+    stage = "DEV"
   )
 
   val result = sl.schedule(config, new FakeContext())

--- a/src/main/scala/com/gu/flexible/snapshotter/mainclasses/SnapshottingLambdaRunner.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/mainclasses/SnapshottingLambdaRunner.scala
@@ -1,6 +1,5 @@
 package com.gu.flexible.snapshotter.mainclasses
 
-import com.amazonaws.regions.{Region, Regions}
 import com.gu.flexible.snapshotter.SnapshottingLambda
 import com.gu.flexible.snapshotter.config.SnapshotterConfig
 import com.gu.flexible.snapshotter.logic.{FutureUtils, SNSLogic}
@@ -16,8 +15,7 @@ object SnapshottingLambdaRunner extends App {
   val config = new SnapshotterConfig(
     bucket = bucket,
     stage = "DEV",
-    stack = stack,
-    region = Region.getRegion(Regions.EU_WEST_1)
+    stack = stack
   )
   val results = sl.snapshot(input,
     config,


### PR DESCRIPTION
## What does this change?

Our AWS SDK is quite out of date, this PR upgrades it to latest.

We're hoping it might help with some intermittent DNS issues we're seeing on this service.

```
Caused by: java.net.UnknownHostException: <bucket name>.s3.eu-west-1.amazonaws.com
```

After upgrading, invokes included a warning log and a stack trace - 
```
WARNING: Unable to retrieve the requested metadata (/latest/dynamic/instance-identity/document). Failed to connect to service endpoint:
```

which were from the default values for `region` in the config classes. `Regions.getCurrentRegion()` only works when running on EC2, otherwise returns `null`. I took a look through the code and the lambdas never try to use this value, so I deleted it to remove the warning and avoid any future confusion over having a null value in there.

## How to test

- [x] Check on CODE that there's no regressions

## How can we measure success?

Do our intermittent snapshot failures from DNS issues get reduced?