### PR TITLE
Adds Snyk Github action

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,6 +1,4 @@
-# This action runs every day at 6 AM and on every push
-# If the branch it's running on is main then it will run snyk monitor (reports vulnerabilities to snyk.io)
-# Otherwise it will run snyk test
+# This action runs every day at 6 AM and on every push to main
 name: Snyk
 
 on:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,26 @@
+# This action runs every day at 6 AM and on every push
+# If the branch it's running on is main then it will run snyk monitor (reports vulnerabilities to snyk.io)
+# Otherwise it will run snyk test
+name: Snyk
+
+on:
+    schedule:
+        - cron: "0 6 * * *"
+    push:
+        branches:
+            - main
+    workflow_dispatch:
+    
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/scala@0.3.0
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --org=guardian --project-name=${{ github.repository }}
+          command: monitor


### PR DESCRIPTION
## What does this change?

This PR adds Snyk CLI integration via a GitHub action workflow. It will provide us with dependency vulnerability visibility of this project. The PR is broadly based on the [recommendations in security HQ](https://github.com/guardian/security-hq/blob/bd7dd44b0ea32eb77979dc36cc9ce409e1266d4d/hq/markdown/snyk.md) and the [editorial tools approach](https://github.com/guardian/flexible-content/blob/main/.github/workflows/snyk.yml). It doesn't use the resuable workflow due it only being a Scala project, allowing us to use the Snyk specific action.

Result can be [found here](https://app.snyk.io/org/guardian/project/e7e68bf7-c806-4214-85e2-542150106ca5/history/3c0b4891-2e4d-4ff1-a69e-5855ccb014d3) from [this run](https://github.com/guardian/flexible-snapshotter/actions/runs/1997786446).

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Are accurate Scala dependency results appearing in Snyk?
