### PR TITLE
Build with GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-java@v3
         with:
-          distribution: "adopt"
+          distribution: "corretto"
           java-version: "8"
           cache: "sbt"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,9 @@ jobs:
 
       - name: Build and Test project
         run: |
-          sbt "clean" "compile" "test" "Universal/packageBin"
-          cp target/scala*/snapshotter-lambda.zip ./snapshotter-lambda.zip
+          sbt sbt clean compile test universal:packageBin
+          cp target/universal snapshotter-lambda.zip ./snapshotter-lambda.zip
+
       - uses: guardian/actions-riff-raff@v2
         with:
           projectName: editorial-tools:flexible:snapshotter-lambda

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Build and Test project
         run: |
-          sbt clean compile test universal:packageBin
+          sbt clean compile test Universal/packageBin
           cp target/universal/snapshotter-lambda.zip ./snapshotter-lambda.zip
 
       - uses: guardian/actions-riff-raff@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: build
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions: # required by aws-actions/configure-aws-credentials
+      id-token: write
+      contents: read
+
+    steps:
+      # Seed the build number with last number from TeamCity.
+      # This env var is used by the JS, and SBT builds, and guardian/actions-riff-raff.
+      # Set the value early, rather than `buildNumberOffset` in guardian/actions-riff-raff, to ensure each usage has the same number.
+      # For some reason, it's not possible to mutate GITHUB_RUN_NUMBER, so set BUILD_NUMBER instead.
+      - name: Set BUILD_NUMBER environment variable
+        run: |
+          LAST_TEAMCITY_BUILD=145
+          echo "BUILD_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))" >> $GITHUB_ENV
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "adopt"
+          java-version: "8"
+          cache: "sbt"
+
+      - name: AWS Auth
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          aws-region: eu-west-1
+
+      - name: Build and Test project
+        run: |
+          sbt clean compile test riffraffupload
+          cp target/scala*/snapshotter-lambda.zip ./snapshotter-lambda.zip
+      - uses: guardian/actions-riff-raff@v2
+        with:
+          projectName: editorial-tools:flexible:snapshotter-lambda
+          buildNumber: ${{ env.BUILD_NUMBER }}
+          configPath: riff-raff.yaml
+          contentDirectories: |
+            snapshotter-lambda:
+              - snapshotter-lambda.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
 
       - name: Build and Test project
         run: |
-          sbt clean compile test riffraffupload
-          cp target/scala*/snapshotter-lambda.zip ./snapshotter-lambda.zip
+          sbt clean compile test Universal/packageBin
+          cp target/scala*/universal/snapshotter-lambda.zip ./snapshotter-lambda.zip
       - uses: guardian/actions-riff-raff@v2
         with:
           projectName: editorial-tools:flexible:snapshotter-lambda

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Build and Test project
         run: |
-          sbt clean compile test Universal/packageBin
+          sbt clean compile test Universal:packageBin
           cp target/scala*/universal/snapshotter-lambda.zip ./snapshotter-lambda.zip
       - uses: guardian/actions-riff-raff@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Build and Test project
         run: |
-          sbt clean compile test Universal:packageBin
+          sbt "clean" "compile" "test" "universal:packageBin"
           cp target/scala*/universal/snapshotter-lambda.zip ./snapshotter-lambda.zip
       - uses: guardian/actions-riff-raff@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Build and Test project
         run: |
-          sbt sbt clean compile test universal:packageBin
+          sbt clean compile test universal:packageBin
           cp target/universal snapshotter-lambda.zip ./snapshotter-lambda.zip
 
       - uses: guardian/actions-riff-raff@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build and Test project
         run: |
           sbt "clean" "compile" "test" "Universal/packageBin"
-          cp target/scala*/universal/snapshotter-lambda.zip ./snapshotter-lambda.zip
+          cp target/scala*/snapshotter-lambda.zip ./snapshotter-lambda.zip
       - uses: guardian/actions-riff-raff@v2
         with:
           projectName: editorial-tools:flexible:snapshotter-lambda

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Build and Test project
         run: |
-          sbt "clean" "compile" "test" "universal:packageBin"
+          sbt "clean" "compile" "test" "Universal/packageBin"
           cp target/scala*/universal/snapshotter-lambda.zip ./snapshotter-lambda.zip
       - uses: guardian/actions-riff-raff@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build and Test project
         run: |
           sbt clean compile test universal:packageBin
-          cp target/universal snapshotter-lambda.zip ./snapshotter-lambda.zip
+          cp target/universal/snapshotter-lambda.zip ./snapshotter-lambda.zip
 
       - uses: guardian/actions-riff-raff@v2
         with:

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ libraryDependencies ++= Seq(
 
 publishMavenStyle := false
 
-enablePlugins(JavaAppPackaging, RiffRaffArtifact)
+enablePlugins(JavaAppPackaging)
 
 Universal / topLevelDirectory := None
 Universal / packageName := normalizedName.value

--- a/build.sbt
+++ b/build.sbt
@@ -38,8 +38,3 @@ enablePlugins(JavaAppPackaging, RiffRaffArtifact)
 
 Universal / topLevelDirectory := None
 Universal / packageName := normalizedName.value
-
-riffRaffPackageType := (Universal / packageBin).value
-riffRaffUploadArtifactBucket := Option("riffraff-artifact")
-riffRaffUploadManifestBucket := Option("riffraff-builds")
-riffRaffManifestProjectName :=  s"editorial-tools:flexible:${name.value}"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,5 @@
 addSbtPlugin("com.github.sbt" %% "sbt-native-packager" % "1.9.9")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
-
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.5.3")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,4 +1,3 @@
-regions: [eu-west-1]
 stacks:
 - flexible
 - flexible-secondary


### PR DESCRIPTION

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adopts GitHub Actions for CI, replacing TeamCity. As far as I could tell, this just required pausing the teamcity build and adding the ci.yml file. 



## How to test

This branch has been built through GHA and successfully deployed to CODE. Looking at the lambda in aws, we can see it's been invoked successfully (looks like it triggers when creating an article in composer code):

![image](https://github.com/guardian/flexible-snapshotter/assets/102960844/8eb5ba4b-582c-43e1-a326-ba5116139f7f)


## How can we measure success/mitigate risks?

Prod gets deployed successfully and the snapshotter continues working. Any issues with the deployment should end up getting rolled back automatically.

## Rollout

- [X]  Pause the TeamCity build
- [x]  Merge this PR
- [x]  Adjust branch protection rules, requiring the GHA build to pass before merge
- [x]  Ensure all open PRs are rebased against main to ensure their build runs

