### PR TITLE
Attempt to add some retry logic for querying composer

### DIFF
--- a/src/main/scala/com/gu/flexible/snapshotter/SchedulingLambda.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/SchedulingLambda.scala
@@ -37,7 +37,7 @@ class SchedulingLambda extends Logging {
     val metadata = SnapshotMetadata("Scheduled snapshot")
 
     for {
-      apiResult <- contentModifiedSince(fiveMinutesAgo)
+      apiResult <- Retry(contentModifiedSince(fiveMinutesAgo), 2)
       contentIds = parseContentIds(apiResult)
       snapshotRequests = contentIds.map(SnapshotRequest(_, metadata))
     } yield {

--- a/src/main/scala/com/gu/flexible/snapshotter/logic/Retry.scala
+++ b/src/main/scala/com/gu/flexible/snapshotter/logic/Retry.scala
@@ -1,0 +1,14 @@
+package com.gu.flexible.snapshotter.logic
+
+import com.gu.flexible.snapshotter.model.Attempt
+
+import scala.concurrent.ExecutionContext
+
+object Retry {
+  def apply[T](f: => Attempt[T], retries: Int)(implicit ec: ExecutionContext): Attempt[T] = {
+    if (retries > 0)
+      f.recoverWith(_ => apply(f, retries - 1))
+    else
+      f
+  }
+}


### PR DESCRIPTION
## What does this change?

Occasionally requests to composer fail with a `java.nio.channels.ClosedChannelException`. I don't know why this is happening, but it seems reasonably safe to try this call 3 times before giving up.

Tested in CODE by deploying, changing an article, and seeing that a snapshot is still created in restorer. Difficult to test the retry logic. I didn't bother to try to induce a failure.