### PR TITLE
Bump slf4j dependencies to hopefully fix logging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,8 @@ val playVersion = "2.2.9"
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.1",
   "com.amazonaws" % "aws-lambda-java-events" % "1.2.1" intransitive(),
-  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.5.1",
-  "org.slf4j" % "slf4j-simple" % "1.7.32",
+  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.6.0",
+  "org.slf4j" % "slf4j-simple" % "2.0.13",
   "net.logstash.log4j" % "jsonevent-layout" % "1.7",
   "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-lambda" % awsVersion,


### PR DESCRIPTION
https://github.com/guardian/flexible-snapshotter/pull/41 introduced a regression in logging. Nothing interesting was logged, where previously there were helpful messages like `Saving content to bucket *** with key ****/2024-12-20T10:14:47.236Z.json`

Helpfully the logs did include:
```
SLF4J(W): No SLF4J providers were found.
SLF4J(W): See https://www.slf4j.org/codes.html#ignoredBindings for an explanation.
SLF4J(W): Defaulting to no-operation (NOP) logger implementation
SLF4J(W): Ignoring binding found at [jar:file:/var/task/lib/org.slf4j.slf4j-simple-1.7.32.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J(W): Class path contains SLF4J bindings targeting slf4j-api versions 1.7.x or earlier.
```

This suggests that bumping the version of slf4j-simple would fix this issue - and it does! I've also bumped `aws-lambda-java-log4j2` since a newer version was available, and I was testing logging anyway.