### PR TITLE
Bump Scala to version 2.13.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 .vscode/
 **/.bloop
 metals.sbt
+**/.DS_Store

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import com.typesafe.sbt.packager.archetypes.JavaAppPackaging._
 name := "snapshotter-lambda"
 organization  := "com.gu"
 
-scalaVersion := "2.13.8"
+scalaVersion := "2.13.9"
 
 description   := "AWS lambdas to snapshot Flexible content to S3"
 scalacOptions ++= Seq(


### PR DESCRIPTION
## What does this change?
Dependabot is reporting a critical vulnerability, which can be fixed by bumping Scala to `v2.13.9` - see https://github.com/guardian/flexible-snapshotter/security/dependabot/2

## How to test
Following on from the test suggestions made in PR #30 ...

**To test in CODE:**
+ Deploy to CODE via riff-raff,
+ Create an article in Composer code,
+ Make changes and hit "save and close"
+ Does the snapshot end up in restorer?